### PR TITLE
Make all models readonly by default

### DIFF
--- a/pantry-finder-api/app/models/application_record.rb
+++ b/pantry-finder-api/app/models/application_record.rb
@@ -3,4 +3,8 @@
 # Base model
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  # This app exposes an existing datasource
+  # Let's treat it as readonly
+  after_initialize :readonly!
 end

--- a/pantry-finder-api/spec/spec_helper.rb
+++ b/pantry-finder-api/spec/spec_helper.rb
@@ -43,4 +43,12 @@ RSpec.configure do |c|
       example.run
     end
   end
+
+  c.before do
+    # Override readonly models to enable factory bot to create records
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ApplicationRecord)
+      .to receive(:readonly?).and_return(false)
+    # rubocop:enable RSpec/AnyInstance
+  end
 end

--- a/pantry-finder-api/spec/spec_helper.rb
+++ b/pantry-finder-api/spec/spec_helper.rb
@@ -45,7 +45,7 @@ RSpec.configure do |c|
   end
 
   c.before do
-    # Override readonly models to enable factory bot to create records
+    # Override readonly models so that factory bot can create records
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(ApplicationRecord)
       .to receive(:readonly?).and_return(false)


### PR DESCRIPTION
This application is exposing an existing datasource. Data is added and the schema is modified outside of the application. So, let's treat every model as readonly by default.

If you accidentally try to delete one of the records the following occurs:
```
irb(main):001:0> Agency.last.destroy
ActiveRecord::ReadOnlyRecord (Agency is marked as readonly)
```