### PR TITLE
Cors true

### DIFF
--- a/pantry-finder-api/config/environments/development.rb
+++ b/pantry-finder-api/config/environments/development.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
 Jets.application.configure do
-  # Example:
-  # config.function.memory_size = 1536
-
-  # config.action_mailer.raise_delivery_errors = false
-  # Docs: http://rubyonjets.com/docs/email-sending/
+  config.cors = '*'
 end


### PR DESCRIPTION
Access to fetch at 'http://localhost:8888/api/agencies?zip_code=43008&event_date=2020-04-25' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
App.js:26 GET http://localhost:8888/api/agencies?zip_code=43008&event_date=2020-04-25 net::ERR_FAILED

To avoid this problem.  Insert the line “config.cors = true”  in your config/appliation.rb file

Jets.application.configure do
  config.project_name = 'pantry-finder-api'
  config.mode = 'api'
  config.cors = true


This will will add a response header with Access-Control-Allow-Origin=‘*’
See https://rubyonjets.com/docs/cors-support/ for more info.
