### PR TITLE
Use codecov bash uploader instead of gh action

### DIFF
--- a/.github/workflows/pantry-finder-api-ci.yml
+++ b/.github/workflows/pantry-finder-api-ci.yml
@@ -58,11 +58,10 @@ jobs:
         run: |
           bundle exec rspec
         working-directory: ${{env.working-directory}}
+      # https://github.com/codecov/codecov-bash
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
-        with:
-          file: ${{env.working-directory}}/coverage/coverage.xml
-          fail_ci_if_error: true
+        run: |
+          bash <(curl -s https://codecov.io/bash)
 
   lint-pantry-finder-api:
     name: Run Linter For Pantry Finder API


### PR DESCRIPTION
Switching to codecov bash uploader since the prebuilt github doesn't currently work - https://github.com/codecov/codecov-action/issues/69 