### PR TITLE
adds distance between zip code centroid and event  in agencies API

### DIFF
--- a/pantry-finder-api/Gemfile
+++ b/pantry-finder-api/Gemfile
@@ -39,3 +39,5 @@ group :test do
 end
 
 gem 'active_model_serializers', '~> 0.10.10'
+
+gem 'geocoder'

--- a/pantry-finder-api/Gemfile.lock
+++ b/pantry-finder-api/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
     faker (2.11.0)
       i18n (>= 1.6, < 2)
     gems (1.2.0)
+    geocoder (1.6.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (4.1.0)
@@ -286,6 +287,7 @@ DEPENDENCIES
   dynomite
   factory_bot (~> 5.1)
   faker (~> 2.11)
+  geocoder
   jets!
   launchy
   mysql2 (~> 0.5.2)

--- a/pantry-finder-api/app/controllers/api/agencies_controller.rb
+++ b/pantry-finder-api/app/controllers/api/agencies_controller.rb
@@ -6,8 +6,8 @@ module Api
     before_action :set_agencies, only: [:index]
 
     def index
-      if (zip = search_params[:zip_code])
-        @agencies = @agencies.by_zip_code(zip)
+      if (@zip = search_params[:zip_code])
+        @agencies = @agencies.by_zip_code(@zip)
       end
       if (date = search_params[:event_date])
         @agencies = @agencies.with_event_after(date.delete('-'))
@@ -32,7 +32,8 @@ module Api
     end
 
     def serialized_agencies
-      ActiveModelSerializers::SerializableResource.new(@agencies).as_json
+      ActiveModelSerializers::SerializableResource.new(@agencies,
+                                                       zip_query: @zip).as_json
     end
   end
 end


### PR DESCRIPTION
The distance requires the use of the zip_code query parameter of the agencies API.  It is calculated using the ZipCode latitude and longitude (centroid) and the Events pt_latitude and pt_longitude through the geocoder gem.  The distance has two significant decimal digits. If no zip_code query is present, the distance will be presented as an empty string, i.e., "".

Example query:
curl --location --request GET 'http://localhost:8888/api/agencies?zip_code=43046&event_date=04-22-2020'

Example response:
<pre>
{
  "agencies": [
    {
      "id": 6,
      "address": "3960 BROOKHAM DR",
      "city": "GROVE CITY",
      "state": "OH",
      "zip": "43123",
      "phone": "614-317-9482",
      "name": "Mid-Ohio Foodbank - Kroger Community Pantry",
      "nickname": "MOF Kroger Pantry",
      "events": [
        {
          "id": 5563,
          "address": "3960 BROOKHAM DR ",
          "city": "Grove City",
          "state": "OH",
          "zip": "43123",
          "agency_id": 6,
          "latitude": "39.8862352",
          "longitude": "-83.05538713",
          "name": "Drive Through",
          "service": "Prepack Pantry",
          "distance": 27.71,
          "event_dates": [
            {
              "id": 10,
              "event_id": 5563,
              "start_time": "01:00 PM",
              "end_time": "03:00 PM",
              "date": "2020-04-22"
            },
            {
              "id": 11,
              "event_id": 5563,
              "start_time": "01:00 PM",
              "end_time": "03:00 PM",
              "date": "2020-04-24"
            },
            {
              "id": 12,
              "event_id": 5563,
              "start_time": "01:00 PM",
              "end_time": "03:00 PM",
              "date": "2020-04-25"
            }
          ]
        }
      ]
    },
    {
      "id": 104,
      "address": "2315 WEEKLY AVE",
      "city": "MILLERSPORT",
      "state": "OH",
      "zip": "43046",
      "phone": "614-314-3901",
      "name": "Millersport Community Food Pantry",
      "nickname": "Millersport Community Food Pantry",
      "events": [
        {
          "id": 159,
          "address": "2315 WEEKLY AVE ",
          "city": "MILLERSPORT",
          "state": "OH",
          "zip": "43046",
          "agency_id": 104,
          "latitude": "39.90037882",
          "longitude": "-82.53778996",
          "name": "Pantry",
          "service": "Choice Pantry",
          "distance": 0.3,
          "event_dates": [
            {
              "id": 28,
              "event_id": 159,
              "start_time": "03:00 PM",
              "end_time": "04:30 PM",
              "date": "2020-04-23"
            },
            {
              "id": 29,
              "event_id": 159,
              "start_time": "03:00 PM",
              "end_time": "04:30 PM",
              "date": "2020-04-24"
            },
            {
              "id": 30,
              "event_id": 159,
              "start_time": "03:00 PM",
              "end_time": "04:30 PM",
              "date": "2020-04-25"
            }
          ]
        }
      ]
    }
  ]
}
</pre>


